### PR TITLE
use pkg_resources to get binary

### DIFF
--- a/imageio_ffmpeg/_utils.py
+++ b/imageio_ffmpeg/_utils.py
@@ -1,11 +1,10 @@
 import os
+from pkg_resources import resource_filename
 import sys
 import subprocess
 import logging
 
 from ._definitions import get_platform, FNAME_PER_PLATFORM
-
-LIB_DIR = os.path.dirname(os.path.abspath(__file__))
 
 logger = logging.getLogger("imageio_ffmpeg")
 
@@ -27,7 +26,8 @@ def get_ffmpeg_exe():
     plat = get_platform()
 
     # 2. Try from here
-    exe = os.path.join(LIB_DIR, "binaries", FNAME_PER_PLATFORM.get(plat, ""))
+    bin_dir = resource_filename("imageio_ffmpeg", "binaries")
+    exe = os.path.join(bin_dir, FNAME_PER_PLATFORM.get(plat, ""))
     if exe and os.path.isfile(exe) and _is_valid_exe(exe):
         return exe
 


### PR DESCRIPTION
I removed ``LIB_DIR``, because it is not used anywhere.
I add ``bin_dir`` in the function, because it triggers an extraction of the binary (if applicable) and should not happen when importing the module. For instance, people might want to use their own exes anyway and not want to wait for pkg_resources to extract another one.

closes #7