### PR TITLE
Add 'ffmpeg_timeout' flag to write_frames

### DIFF
--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -216,6 +216,7 @@ def write_frames(
     codec=None,
     macro_block_size=16,
     ffmpeg_log_level="warning",
+    ffmpeg_timeout=5.0,
     input_params=None,
     output_params=None,
 ):
@@ -249,6 +250,8 @@ def write_frames(
             to this value to avoid image resizing. Default 16. Can be set
             to 1 to avoid block alignment, though this is not recommended.
         ffmpeg_log_level (str): The ffmpeg logging level.
+        ffmpeg_timeout (float): Timeout in seconds to wait for ffmpeg process
+            to respond. Value of 0 will wait forever.
         input_params (list): Additional ffmpeg input command line parameters.
         output_params (list): Additional ffmpeg output command line parameters.
     """
@@ -421,8 +424,8 @@ def write_frames(
 
             # Wait for it to stop. The above will signal that we're done,
             # but ffmpeg wrapping up takes a bit of time
-            etime = time.time() + 2.5
-            while time.time() < etime and p.poll() is None:
+            etime = time.time() + ffmpeg_timeout
+            while (not ffmpeg_timeout or time.time() < etime) and p.poll() is None:
                 time.sleep(0.01)
 
             # Grr, we have to kill it

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -276,7 +276,9 @@ def test_write_big_frames():
 
     # short timeout is not enough time
     _write_frames("rgb24", 3, 2.0)
-    raises(subprocess.CalledProcessError, imageio_ffmpeg.count_frames_and_secs, test_file2)
+    raises(
+        subprocess.CalledProcessError, imageio_ffmpeg.count_frames_and_secs, test_file2
+    )
 
     _write_frames("gray", 1, 15.0)
     nframes, nsecs = imageio_ffmpeg.count_frames_and_secs(test_file2)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -267,10 +267,7 @@ def test_write_big_frames():
             test_file2, (2048, 2048), pix_fmt_in=pixfmt, ffmpeg_timeout=20.0)
         gen.send(None)  # seed
         for i in range(9):
-            data = (255 * np.random.rand(2048 * 2048 * bpp)).astype(int)
-            print(data.shape)
-            data = bytes(data)
-            # data = bytes((255 * np.random.rand(2048 * 2048 * bpp)).astype(int))
+            data = bytes((255 * np.random.rand(2048 * 2048 * bpp)).astype(int))
             gen.send(data)
         gen.close()
         with open(test_file2, "rb") as f:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -264,10 +264,10 @@ def test_write_big_frames():
     for pixfmt, bpp in [("gray", 1), ("rgb24", 3), ("rgba", 4)]:
         # Prepare for writing
         gen = imageio_ffmpeg.write_frames(
-            test_file2, (2048, 2048), pix_fmt_in=pixfmt, ffmpeg_timeout=20.0)
+            test_file2, (2048, 2048), pix_fmt_in=pixfmt, ffmpeg_timeout=10.0)
         gen.send(None)  # seed
         for i in range(9):
-            data = bytes((255 * np.random.rand(2048 * 2048 * bpp)).astype(int))
+            data = bytes((255 * np.random.rand(2048 * 2048 * bpp)).astype(np.uint8))
             gen.send(data)
         gen.close()
         with open(test_file2, "rb") as f:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -264,7 +264,7 @@ def test_write_big_frames():
     for pixfmt, bpp in [("gray", 1), ("rgb24", 3), ("rgba", 4)]:
         # Prepare for writing
         gen = imageio_ffmpeg.write_frames(
-            test_file2, (2048, 2048), pix_fmt_in=pixfmt, ffmpeg_timeout=10.0)
+            test_file2, (2048, 2048), pix_fmt_in=pixfmt, ffmpeg_timeout=20.0)
         gen.send(None)  # seed
         for i in range(9):
             data = bytes((255 * np.random.rand(2048 * 2048 * bpp)).astype(np.uint8))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -267,7 +267,8 @@ def test_write_big_frames():
             test_file2, (2048, 2048), pix_fmt_in=pixfmt, ffmpeg_timeout=20.0)
         gen.send(None)  # seed
         for i in range(9):
-            data = bytes((255 * np.random.rand(2048 * 2048 * bpp)).astype(np.uint8))
+            data = (255 * np.random.rand(2048 * 2048 * bpp)).astype(np.uint8)
+            data = bytes(data)
             gen.send(data)
         gen.close()
         with open(test_file2, "rb") as f:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -264,7 +264,8 @@ def test_write_big_frames():
     for pixfmt, bpp in [("gray", 1), ("rgb24", 3), ("rgba", 4)]:
         # Prepare for writing
         gen = imageio_ffmpeg.write_frames(
-            test_file2, (2048, 2048), pix_fmt_in=pixfmt, ffmpeg_timeout=20.0)
+            test_file2, (2048, 2048), pix_fmt_in=pixfmt, ffmpeg_timeout=20.0
+        )
         gen.send(None)  # seed
         for i in range(9):
             data = (255 * np.random.rand(2048 * 2048 * bpp)).astype(np.uint8)


### PR DESCRIPTION
Possible solution/workaround for #13. This PR adds the 'ffmpeg_timeout' keyword argument to `write_frames` so the user can ask for imageio to wait longer for ffmpeg to finish. This is especially important when writing larger frames where ffmpeg may need more time.