### PR TITLE
 Tweaks to killing ffmpeg on writing 

### DIFF
--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -220,7 +220,7 @@ def write_frames(
     codec=None,
     macro_block_size=16,
     ffmpeg_log_level="warning",
-    ffmpeg_timeout=5.0,
+    ffmpeg_timeout=20.0,
     input_params=None,
     output_params=None,
 ):
@@ -255,7 +255,8 @@ def write_frames(
             to 1 to avoid block alignment, though this is not recommended.
         ffmpeg_log_level (str): The ffmpeg logging level. Default "warning".
         ffmpeg_timeout (float): Timeout in seconds to wait for ffmpeg process
-            to respond. Value of 0 will wait forever. Default 5.0.
+            to finish. Value of 0 will wait forever. The time that ffmpeg needs
+            depends on CPU speed, compression, and frame size. Default 20.0.
         input_params (list): Additional ffmpeg input command line parameters.
         output_params (list): Additional ffmpeg output command line parameters.
     """

--- a/tasks.py
+++ b/tasks.py
@@ -47,12 +47,14 @@ def lint(ctx):
     except ImportError:
         sys.exit("You need to ``pip install flake8`` to lint")
 
+    print("Checking linting errors with flake8:")
+
     # We use flake8 with minimal settings
     # http://pep8.readthedocs.io/en/latest/intro.html#error-codes
     cmd = [sys.executable, "-m", "flake8"] + PY_PATHS + ["--select=F,E11"]
     ret_code = subprocess.call(cmd, cwd=ROOT_DIR)
     if ret_code == 0:
-        print("No style errors found")
+        print("No linting errors found")
     else:
         sys.exit(ret_code)
 
@@ -61,6 +63,7 @@ def lint(ctx):
 def checkformat(ctx):
     """ Check whether the code adheres to the style rules. Use autoformat to fix.
     """
+    print("Checking format with black (also see invoke autoformat):")
     black_wrapper(False)
 
 
@@ -68,6 +71,7 @@ def checkformat(ctx):
 def autoformat(ctx):
     """ Automatically format the code (using black).
     """
+    print("Auto-formatting with black:")
     black_wrapper(True)
 
 


### PR DESCRIPTION
* I tried reducing the buffersize of stdin, and using `stdin.flush`, but this has no effect on the wait time.
* Made the default timeout much longer (20s)
* Better message when ffmpeg is killed (tell user to increase `ffmpeg_timeout`)
* Handle case where Python gets interrupted during waiting for ffmpeg to finish.
* Clarify some invoke tasks by making them print some more info about what they're doing.

Related to #13. Builds on #14.