### PR TITLE
Fix hang in read_frames fixes #17

### DIFF
--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -190,7 +190,7 @@ def read_frames(path, pix_fmt="rgb24", bpp=3, input_params=None, output_params=N
             # Ask ffmpeg to quit
             try:
                 if True:
-                    p.stdin.write("q")
+                    p.stdin.write(b"q")
                     p.stdin.close()
                 else:  # pragma: no cover
                     # I read somewhere that modern ffmpeg on Linux prefers a

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -186,6 +186,7 @@ def read_frames(path, pix_fmt="rgb24", bpp=3, input_params=None, output_params=N
         # so this code is almost guaranteed to run.
 
         if p.poll() is None:
+
             # Ask ffmpeg to quit
             try:
                 if True:

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -186,27 +186,27 @@ def read_frames(path, pix_fmt="rgb24", bpp=3, input_params=None, output_params=N
         # so this code is almost guaranteed to run.
 
         if p.poll() is None:
-
             # Ask ffmpeg to quit
             try:
-                if True:
-                    p.communicate(b"q")
-                else:  # pragma: no cover
-                    # I read somewhere that modern ffmpeg on Linux prefers a
-                    # "ctrl-c", but tests so far suggests sending q is better.
-                    p.send_signal(signal.SIGINT)
+                # I read somewhere that modern ffmpeg on Linux prefers a
+                # "ctrl-c", but tests so far suggests sending q is better.
+                # Except that on Linux, sending q can hang indefinitely
+                # even with a timeout, so use "ctrl-c".
+                # p.communicate(b"q")
+                p.send_signal(signal.SIGINT)
             except Exception as err:  # pragma: no cover
                 logger.warning("Error while attempting stop ffmpeg: " + str(err))
-
-            # Wait for it to stop
-            etime = time.time() + 1.5
-            while time.time() < etime and p.poll() is None:
-                time.sleep(0.01)
+            else:
+                try:
+                    p.wait(timeout=1.5)
+                except subprocess.TimeoutExpired:
+                    pass
 
             # Grr, we have to kill it
             if p.poll() is None:  # pragma: no cover
                 logger.warning("We had to kill ffmpeg to stop it.")
                 p.kill()
+                p.wait()
 
 
 def write_frames(

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -208,6 +208,7 @@ def read_frames(path, pix_fmt="rgb24", bpp=3, input_params=None, output_params=N
             if p.poll() is None:  # pragma: no cover
                 logger.warning("We had to kill ffmpeg to stop it.")
                 p.kill()
+                p.wait()
 
 
 def write_frames(

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -186,27 +186,10 @@ def read_frames(path, pix_fmt="rgb24", bpp=3, input_params=None, output_params=N
         # so this code is almost guaranteed to run.
 
         if p.poll() is None:
-            # Ask ffmpeg to quit
-            try:
-                # I read somewhere that modern ffmpeg on Linux prefers a
-                # "ctrl-c", but tests so far suggests sending q is better.
-                # Except that on Linux, sending q can hang indefinitely
-                # even with a timeout, so use "ctrl-c".
-                # p.communicate(b"q")
-                p.send_signal(signal.SIGINT)
-            except Exception as err:  # pragma: no cover
-                logger.warning("Error while attempting stop ffmpeg: " + str(err))
-            else:
-                try:
-                    p.wait(timeout=1.5)
-                except subprocess.TimeoutExpired:
-                    pass
-
-            # Grr, we have to kill it
-            if p.poll() is None:  # pragma: no cover
-                logger.warning("We had to kill ffmpeg to stop it.")
-                p.kill()
-                p.wait()
+            # Sending q, ctrl-c, or SIGTERM are more polite ways to kill the subprocess
+            # but on Linux, sending q can hang even with a timeout and other signals appear to be ignored.
+            p.kill()
+            p.wait()
 
 
 def write_frames(


### PR DESCRIPTION
This is to fix #17, it's not clear to me why `p.communicate()` with a timeout still hangs, nor why `p.send_signal(signal.SIGINT)` doesn't cause a graceful exit.  But since they don't seem to work, and this is reading data, not writing it, seems fine to simply terminate the subprocess.

Is there any downside to this @almarklein?