### PR TITLE
read_frames hangs on invalid video

### DIFF
--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -140,9 +140,11 @@ def read_frames(path, pix_fmt="rgb24", bpp=3, input_params=None, output_params=N
 
         # Wait for the log catcher to get the meta information
         etime = time.time() + 10.0
-        while log_catcher.isAlive() and \
-                not log_catcher.header and \
-                time.time() < etime:
+        while (
+                log_catcher.is_alive() and
+                not log_catcher.header and
+                time.time() < etime
+        ):
             time.sleep(0.01)
 
         # Check whether we have the information

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -140,11 +140,7 @@ def read_frames(path, pix_fmt="rgb24", bpp=3, input_params=None, output_params=N
 
         # Wait for the log catcher to get the meta information
         etime = time.time() + 10.0
-        while (
-                log_catcher.is_alive() and
-                not log_catcher.header and
-                time.time() < etime
-        ):
+        while log_catcher.is_alive() and not log_catcher.header and time.time() < etime:
             time.sleep(0.01)
 
         # Check whether we have the information

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -140,7 +140,9 @@ def read_frames(path, pix_fmt="rgb24", bpp=3, input_params=None, output_params=N
 
         # Wait for the log catcher to get the meta information
         etime = time.time() + 10.0
-        while (not log_catcher.header) and time.time() < etime:
+        while log_catcher.isAlive() and \
+                not log_catcher.header and \
+                time.time() < etime:
             time.sleep(0.01)
 
         # Check whether we have the information

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 import os
 import types
 import tempfile
+import time
 from urllib.request import urlopen
 
 from pytest import skip, raises
@@ -91,6 +92,25 @@ def test_reading3():
         assert isinstance(frame, bytes) and len(frame) == framesize
 
     assert 50 < count < 100  # because smaller fps, same duration
+
+
+def test_reading_invalid_video():
+    """
+    Check whether invalid video is
+    handled correctly without timeouts
+    """
+    # empty file as an example of invalid video
+    _, test_invalid_file = tempfile.mkstemp(dir=test_dir)
+    gen = imageio_ffmpeg.read_frames(test_invalid_file)
+
+    start = time.time()
+    with raises(OSError):
+        gen.__next__()
+    end = time.time()
+    
+    # check if metadata extraction doesn't hang
+    # for a timeout period
+    assert end - start < 1, "Metadata extraction hangs"
 
 
 def test_reading4():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -94,6 +94,20 @@ def test_reading3():
     assert 50 < count < 100  # because smaller fps, same duration
 
 
+def test_reading4():
+    # Same as 1, but wrong, using an insane bpp, to invoke eof halfway a frame
+
+    gen = imageio_ffmpeg.read_frames(test_file1, bpp=13)
+    gen.__next__()  # == meta
+
+    with raises(RuntimeError) as info:
+        for frame in gen:
+            pass
+    msg = str(info.value).lower()
+    assert "end of file reached before full frame could be read" in msg
+    assert "ffmpeg version" in msg  # The log is included
+
+
 def test_reading_invalid_video():
     """
     Check whether invalid video is
@@ -107,24 +121,10 @@ def test_reading_invalid_video():
     with raises(OSError):
         gen.__next__()
     end = time.time()
-    
+
     # check if metadata extraction doesn't hang
     # for a timeout period
     assert end - start < 1, "Metadata extraction hangs"
-
-
-def test_reading4():
-    # Same as 1, but wrong, using an insane bpp, to invoke eof halfway a frame
-
-    gen = imageio_ffmpeg.read_frames(test_file1, bpp=13)
-    gen.__next__()  # == meta
-
-    with raises(RuntimeError) as info:
-        for frame in gen:
-            pass
-    msg = str(info.value).lower()
-    assert "end of file reached before full frame could be read" in msg
-    assert "ffmpeg version" in msg  # The log is included
 
 
 def test_write1():
@@ -323,6 +323,7 @@ if __name__ == "__main__":
     test_reading2()
     test_reading3()
     test_reading4()
+    test_reading_invalid_video()
     test_write1()
     test_write_pix_fmt_in()
     test_write_pix_fmt_out()


### PR DESCRIPTION
## Bug: `read_frames` hangs for 10s on invalid video files

### Code
```python
import imageio

imageio.get_reader(b'', 'ffmpeg')
```
### Expected
The reader immediately raises the `OSError` exception.

### Actual
The reader **hangs for 10s** and raises the `OSError` exception.

## Cause
`read_frames` waiting from `log_catcher` for the header within the 10s timeout range. Invalid videos produce no header thereby `read_frames` hangs even when `log_catcher`'s thread was terminated.
https://github.com/imageio/imageio-ffmpeg/blob/master/imageio_ffmpeg/_io.py#L141-L144

## Solution
Check if `log_catcher`'s thread was terminated in metadata extraction.
