### PR TITLE
added bits_per_pixel parameter to read_frames

### DIFF
--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -92,16 +92,16 @@ def read_frames(path, pix_fmt="rgb24", bpp=None, input_params=None, output_param
             print(len(frame))
     
     Parameters:
-        path (str): the file to write to.
+        path (str): the file path to read from.
         pix_fmt (str): the pixel format of the frames to be read.
             The default is "rgb24" (frames are uint8 RGB images).
-        bpp (int): The number of bytes per pixel in the output frames.
-            This depends on the given pix_fmt. Default is 3 (RGB).
         input_params (list): Additional ffmpeg input command line parameters.
         output_params (list): Additional ffmpeg output command line parameters.
         bits_per_pixel (int): The number of bits per pixel in the output frames.
-            This depends on the given pix_fmt. Yuv format can have 12 bits per pixel,
-            so bpp attribute useless
+            This depends on the given pix_fmt. Default is 24 (RGB)
+        bpp (int): DEPRECATED, USE bits_per_pixel INSTEAD. The number of bytes per pixel in the output frames.
+            This depends on the given pix_fmt. Some pixel formats like yuv420p have 12 bits per pixel
+            and cannot be set in bytes as integer. For this reason the bpp argument is deprecated.
     """
 
     # ----- Input args


### PR DESCRIPTION
Bug: `read_frames` read 2 frames as one from 
==

Code
===
```
import os
import tempfile
from urllib.request import urlopen

import imageio_ffmpeg


url = "https://raw.githubusercontent.com/imageio/imageio-binaries/master/images/realshort.mp4"
content = urlopen(url).read()
file_path = os.path.join(tempfile.gettempdir(), "cockatoo.mp4")
with open(file_path, "wb") as f:
    f.write(content)

gen = imageio_ffmpeg.read_frames(file_path, pix_fmt="yuv420p")

meta = gen.__next__()
frames_count_meta = meta['fps'] * meta['duration']
frames = list(gen)
print(f'{frames_count_meta} vs {len(frames)}')
```

Expected
===
`36.024 vs 36`


Result
===
`36.024 vs 18`

Cause
===
`read_frames` can handle only bytes per pixel, but yuv 420 has 6 bytes per 4 pixels (12 bits per 1 pixel). By default `read_frames` read 3 bytes per pixel, but because yuv420 has 2 pixel in 3 bytes we have 18 frames instead of 36.

Solutions
===
`read_frames` take `bpp` as int, so we can't pass 1.5, so we can add `bits_per_pixel ` and don't remove `bpp` for backward compatibility 

Related issue: #24 
