### PR TITLE
Avoid exception under Cygwin

### DIFF
--- a/imageio_ffmpeg/_definitions.py
+++ b/imageio_ffmpeg/_definitions.py
@@ -10,6 +10,8 @@ def get_platform():
         return "linux{}".format(bits)
     elif sys.platform.startswith("win"):
         return "win{}".format(bits)
+    elif sys.platform.startswith("cygwin"):
+        return "win{}".format(bits)
     elif sys.platform.startswith("darwin"):
         return "osx{}".format(bits)
     else:  # pragma: no cover


### PR DESCRIPTION
Cygwin is a hybrid between Windows and Unix.  It does not currently
provide ffmpeg as a package, so the user will have to rely on Windows
builds, such as the [Zeranoe](https://ffmpeg.zeranoe.com/builds/) ones.
Setting winNN can work with such an installation and a suitable path.

Issue: #26