### PR TITLE
Tweaks and fixes

### DIFF
--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -1,6 +1,7 @@
 import sys
 import time
 import signal
+import pathlib
 import subprocess
 
 from ._utils import get_ffmpeg_exe, logger
@@ -31,7 +32,10 @@ def count_frames_and_secs(path):
     """
     # https://stackoverflow.com/questions/2017843/fetch-frame-count-with-ffmpeg
 
-    assert isinstance(path, str), "Video path must be a string"
+    if isinstance(path, pathlib.PurePath):
+        path = str(path)
+    if not isinstance(path, str):
+        raise TypeError("Video path must be a string or pathlib.Path.")
 
     cmd = [_get_exe(), "-i", path, "-map", "0:v:0", "-c", "copy", "-f", "null", "-"]
     try:
@@ -60,7 +64,14 @@ def count_frames_and_secs(path):
     raise RuntimeError("Could not get number of frames")  # pragma: no cover
 
 
-def read_frames(path, pix_fmt="rgb24", bpp=None, input_params=None, output_params=None, bits_per_pixel=None):
+def read_frames(
+    path,
+    pix_fmt="rgb24",
+    bpp=None,
+    input_params=None,
+    output_params=None,
+    bits_per_pixel=None,
+):
     """
     Create a generator to iterate over the frames in a video file.
     
@@ -106,7 +117,10 @@ def read_frames(path, pix_fmt="rgb24", bpp=None, input_params=None, output_param
 
     # ----- Input args
 
-    assert isinstance(path, str), "Video path must be a string"
+    if isinstance(path, pathlib.PurePath):
+        path = str(path)
+    if not isinstance(path, str):
+        raise TypeError("Video path must be a string or pathlib.Path.")
     # Note: Dont check whether it exists. The source could be e.g. a camera.
 
     pix_fmt = pix_fmt or "rgb24"
@@ -163,7 +177,9 @@ def read_frames(path, pix_fmt="rgb24", bpp=None, input_params=None, output_param
         w, h = meta["size"]
         framesize_bits = w * h * bits_per_pixel
         framesize_bytes = framesize_bits / 8
-        assert framesize_bytes.is_integer(), "incorrect bits_per_pixel, framesize in bytes must be an int"
+        assert (
+            framesize_bytes.is_integer()
+        ), "incorrect bits_per_pixel, framesize in bytes must be an int"
         framesize_bytes = int(framesize_bytes)
         framenr = 0
 
@@ -272,7 +288,10 @@ def write_frames(
 
     # ----- Input args
 
-    assert isinstance(path, str), "Video path must be a string"
+    if isinstance(path, pathlib.PurePath):
+        path = str(path)
+    if not isinstance(path, str):
+        raise TypeError("Video path must be a string or pathlib.Path.")
 
     # The pix_fmt_out yuv420p is the best for the outpur to work in
     # QuickTime and most other players. These players only support
@@ -407,7 +426,7 @@ def write_frames(
         while True:
 
             # Get frame
-            bb = (yield)
+            bb = yield
 
             # framesize = size[0] * size[1] * depth * bpp
             # assert isinstance(bb, bytes), "Frame must be send as bytes"

--- a/imageio_ffmpeg/_utils.py
+++ b/imageio_ffmpeg/_utils.py
@@ -53,11 +53,6 @@ def get_ffmpeg_exe():
     )
 
 
-def _pre_exec():
-    # To ignore CTRL+C signal in the new process
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
-
-
 def _popen_kwargs():
     startupinfo = None
     preexec_fn = None
@@ -71,7 +66,7 @@ def _popen_kwargs():
     else:
         # Prevent propagation of sigint (see #4)
         # https://stackoverflow.com/questions/5045771
-        preexec_fn = _pre_exec
+        preexec_fn = os.setpgrp  # the _pre_exec does not seem to work
     return {
         "startupinfo": startupinfo,
         "creationflags": creationflags,

--- a/imageio_ffmpeg/_utils.py
+++ b/imageio_ffmpeg/_utils.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import signal
 import logging
 import subprocess
 from pkg_resources import resource_filename

--- a/imageio_ffmpeg/_utils.py
+++ b/imageio_ffmpeg/_utils.py
@@ -57,14 +57,13 @@ def _is_valid_exe(exe):
     try:
         with open(os.devnull, "w") as null:
             hide_window = None
-            if os.name == 'nt':
+            if os.name == "nt":
                 # stops executable from flashing on Windows
                 hide_window = subprocess.STARTUPINFO()
                 hide_window.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             subprocess.check_call(
-                cmd, stdout=null, stderr=subprocess.STDOUT,
-                startupinfo=hide_window
-                )
+                cmd, stdout=null, stderr=subprocess.STDOUT, startupinfo=hide_window
+            )
         return True
     except (OSError, ValueError, subprocess.CalledProcessError):
         return False
@@ -76,13 +75,13 @@ def get_ffmpeg_version():
     """
     exe = get_ffmpeg_exe()
     hide_window = None
-    if os.name == 'nt':
+    if os.name == "nt":
         # stops executable from flashing on Windows
         hide_window = subprocess.STARTUPINFO()
         hide_window.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-    line = subprocess.check_output(
-        [exe, "-version"], startupinfo=hide_window
-        ).split(b"\n", 1)[0]
+    line = subprocess.check_output([exe, "-version"], startupinfo=hide_window).split(
+        b"\n", 1
+    )[0]
     line = line.decode(errors="ignore").strip()
     version = line.split("version", 1)[-1].lstrip().split(" ", 1)[0].strip()
     return version

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -117,7 +117,9 @@ def test_reading5():
     # Same as 1, but using other pixel format and bits_per_pixel
     bits_per_pixel = 12
     bits_per_bytes = 8
-    gen = imageio_ffmpeg.read_frames(test_file3, pix_fmt="yuv420p", bits_per_pixel=bits_per_pixel)
+    gen = imageio_ffmpeg.read_frames(
+        test_file3, pix_fmt="yuv420p", bits_per_pixel=bits_per_pixel
+    )
 
     meta = gen.__next__()
     assert isinstance(meta, dict)


### PR DESCRIPTION
* Support for pathlib.Path (and black formatting)
* Sets default `ffmpeg_timeout` to 0 (wait without timeout). Closes #30 
* Prevent sigint from propagating to ffmpeg. Closes #4 
* When interruping (ctrl-c, KeyBoardInterrupt, SystemExit) during reading or writing, we terminate ffmpeg without waiting.
* Fixes that we actually close ffmpeg nicely after reading, without hanging. Related to #17 and  #19.
* This also closes #20 (technically #19 already fixed the segfault, this PR makes sure we terminate ffmpeg in a nicer way).
