### PR TITLE
Fix compatibility with python3.9

### DIFF
--- a/imageio_ffmpeg/_parsing.py
+++ b/imageio_ffmpeg/_parsing.py
@@ -43,7 +43,7 @@ class LogCatcher(threading.Thread):
         # Wait?
         if timeout > 0:
             etime = time.time() + timeout
-            while self.isAlive() and time.time() < etime:  # pragma: no cover
+            while self.is_alive() and time.time() < etime:  # pragma: no cover
                 time.sleep(0.01)
         # Return str
         lines = b"\n".join(self._lines)


### PR DESCRIPTION
From https://docs.python.org/3/whatsnew/3.9.html:

> The isAlive() method of threading.Thread has been removed. It was deprecated since Python 3.8. Use is_alive() instead. (Contributed by Dong-hee Na in bpo-37804.)