### PR TITLE
Add support for encoding with audio from a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ def write_frames(
     ffmpeg_timeout=0,
     input_params=None,
     output_params=None,
+    audio_path=None,
+    audio_codec=None,
 ):
     """
     Create a generator to write frames (bytes objects) into a video file.
@@ -205,6 +207,8 @@ def write_frames(
             ffmpeg needs depends on CPU speed, compression, and frame size.
         input_params (list): Additional ffmpeg input command line parameters.
         output_params (list): Additional ffmpeg output command line parameters.
+        audio_path (str): A input file path for encoding with an audio stream.
+        audio_codec (str): The audio codec to use if audio_path is provided.
     """
 ```
 

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -315,7 +315,10 @@ def write_frames(
         input_params (list): Additional ffmpeg input command line parameters.
         output_params (list): Additional ffmpeg output command line parameters.
         audio_path (str): A input file path for encoding with an audio stream.
+            Default None, no audio.
         audio_codec (str): The audio codec to use if audio_path is provided.
+            "copy" will try to use audio_path's audio codec without re-encoding.
+            Default None, but some formats must have certain codecs specified.
     """
 
     # ----- Input args
@@ -377,7 +380,7 @@ def write_frames(
         default_codec = "msmpeg4"
     codec = codec or default_codec
 
-    audio_params = []
+    audio_params = ["-an"]
     if audio_path is not None and not path.lower().endswith(".gif"):
         audio_params = ["-i", audio_path]
         if audio_codec is not None:

--- a/imageio_ffmpeg/_parsing.py
+++ b/imageio_ffmpeg/_parsing.py
@@ -137,7 +137,9 @@ def parse_ffmpeg_header(text):
 
     if len(audiolines) > 0:
         audio_line = audiolines[0]
-        meta["audio_codec"] = audio_line.split("Audio: ", 1)[-1].lstrip().split(" ", 1)[0].strip()
+        meta["audio_codec"] = (
+            audio_line.split("Audio: ", 1)[-1].lstrip().split(" ", 1)[0].strip()
+        )
 
     # get the frame rate.
     # matches can be empty, see #171, assume nframes = inf

--- a/imageio_ffmpeg/_parsing.py
+++ b/imageio_ffmpeg/_parsing.py
@@ -130,6 +130,15 @@ def parse_ffmpeg_header(text):
     meta["codec"] = line.split("Video: ", 1)[-1].lstrip().split(" ", 1)[0].strip()
     meta["pix_fmt"] = line.split("Video: ", 1)[-1].split(",")[1].strip()
 
+    # get the output line that speaks about audio
+    audiolines = [
+        l for l in lines if l.lstrip().startswith("Stream ") and " Audio: " in l
+    ]
+
+    if len(audiolines) > 0:
+        audio_line = audiolines[0]
+        meta["audio_codec"] = audio_line.split("Audio: ", 1)[-1].lstrip().split(" ", 1)[0].strip()
+
     # get the frame rate.
     # matches can be empty, see #171, assume nframes = inf
     # the regexp omits values of "1k tbr" which seems a specific edge-case #262

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -353,7 +353,9 @@ def test_write_big_frames():
 def test_write_audio_path():
     # Provide an audio
 
-    gen = imageio_ffmpeg.write_frames(test_file2, (64, 64), audio_path=test_file3, audio_codec='aac')
+    gen = imageio_ffmpeg.write_frames(
+        test_file2, (64, 64), audio_path=test_file3, audio_codec="aac"
+    )
     gen.send(None)  # seed
     for i in range(9):
         data = bytes([min(255, 100 + i * 10)] * 64 * 64 * 3)
@@ -367,7 +369,7 @@ def test_write_audio_path():
     audio_codec = meta["audio_codec"]
 
     assert nframes == 9
-    assert audio_codec == 'aac'
+    assert audio_codec == "aac"
 
 
 if __name__ == "__main__":
@@ -387,3 +389,4 @@ if __name__ == "__main__":
     test_write_bitrate()
     test_write_macro_block_size()
     test_write_big_frames()
+    test_write_audio_path()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -349,6 +349,27 @@ def test_write_big_frames():
     assert nframes == n
 
 
+@no_warnings_allowed
+def test_write_audio_path():
+    # Provide an audio
+
+    gen = imageio_ffmpeg.write_frames(test_file2, (64, 64), audio_path=test_file3, audio_codec='aac')
+    gen.send(None)  # seed
+    for i in range(9):
+        data = bytes([min(255, 100 + i * 10)] * 64 * 64 * 3)
+        gen.send(data)
+    gen.close()
+    # Check nframes
+    nframes, nsecs = imageio_ffmpeg.count_frames_and_secs(test_file2)
+    assert nframes == 9
+    # Check size
+    meta = imageio_ffmpeg.read_frames(test_file2).__next__()
+    audio_codec = meta["audio_codec"]
+
+    assert nframes == 9
+    assert audio_codec == 'aac'
+
+
 if __name__ == "__main__":
     setup_module()
     test_ffmpeg_version()


### PR DESCRIPTION
This adds support for encoding with an audio stream from a file path along with an option to provide an output audio codec.

Strings `audio_path` and `audio_codec` can be provided to the `write_frames` method.

It outputs a warning but successfully encodes the video when the stream provided as `audio_path` has no audio stream.
It also adds an `audio_codec` key to the metadata when reading if an audio stream is present - with output gathered in a similar way to the video metadata.

Tried to keep it minimal; let me know if you want me to change anything.

#50 