### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/imageio_ffmpeg/_parsing.py
+++ b/imageio_ffmpeg/_parsing.py
@@ -18,7 +18,7 @@ class LogCatcher(threading.Thread):
         self._lines = []
         self._remainder = b""
         threading.Thread.__init__(self)
-        self.setDaemon(True)  # do not let this thread hold up Python shutdown
+        self.daemon = True  # do not let this thread hold up Python shutdown
         self._should_stop = False
         self.start()
 


### PR DESCRIPTION
Fixes #55 