### PR TITLE
Optional disabling of `prevent_sigint`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Tidelift will coordinate the fix and disclosure.
 
 ## API
 
+The library can be configured at runtime by setting the following environment
+variables:
+* `IMAGEIO_FFMPEG_EXE=[file name]` -- override the ffmpeg executable;
+* `IMAGEIO_FFMPEG_NO_PREVENT_SIGINT=1` -- don't prevent propagation of SIGINT
+  to the ffmpeg process.
+
 ```py
 def read_frames(
     path,

--- a/imageio_ffmpeg/_utils.py
+++ b/imageio_ffmpeg/_utils.py
@@ -67,6 +67,12 @@ def _popen_kwargs(prevent_sigint=False):
             creationflags = 0x00000200
         else:
             preexec_fn = os.setpgrp  # the _pre_exec does not seem to work
+
+    falsy = ("", "0", "false", "no")
+    if os.getenv("IMAGEIO_FFMPEG_NO_PREVENT_SIGINT", "").lower() not in falsy:
+        # Unset preexec_fn to work around a strange hang on fork() (see #58)
+        preexec_fn = None
+
     return {
         "startupinfo": startupinfo,
         "creationflags": creationflags,


### PR DESCRIPTION
This is a workaround for a strange hang on fork() when `Popen` is called with
a `preexec_fn` (see #58). If the environment variable
`IMAGEIO_FFMPEG_NO_PREVENT_SIGINT` is not empty, `preexec_fn` is set to
None.