### PR TITLE
Fix issue 61: explicitly close stderr stream when read_frames exits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: Lint

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -243,6 +243,8 @@ def read_frames(
                 # p.stdin.write(b"q")  # commented out in v0.4.1
                 p.stdout.close()
                 p.stdin.close()
+                log_catcher.stop_me()
+                p.stderr.close()
             except Exception as err:  # pragma: no cover
                 logger.warning("Error while attempting stop ffmpeg (r): " + str(err))
 
@@ -260,8 +262,6 @@ def read_frames(
             else:  # stop_policy == "kill"
                 # Just kill it
                 p.kill()
-        # close stderr at the very end
-        p.stderr.close()
 
 
 def write_frames(

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -243,10 +243,6 @@ def read_frames(
                 # p.stdin.write(b"q")  # commented out in v0.4.1
                 p.stdout.close()
                 p.stdin.close()
-                try:
-                    p.stderr.close()
-                except Exception:
-                    pass
             except Exception as err:  # pragma: no cover
                 logger.warning("Error while attempting stop ffmpeg (r): " + str(err))
 
@@ -264,6 +260,8 @@ def read_frames(
             else:  # stop_policy == "kill"
                 # Just kill it
                 p.kill()
+        # close stderr at the very end
+        p.stderr.close()
 
 
 def write_frames(

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -261,7 +261,7 @@ def read_frames(
                 # Just kill it
                 p.kill()
         # close stderr at the very end
-        p.stderr.close()
+        #p.stderr.close()
 
 
 def write_frames(

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -261,7 +261,7 @@ def read_frames(
                 # Just kill it
                 p.kill()
         # close stderr at the very end
-        #p.stderr.close()
+        # p.stderr.close()
 
 
 def write_frames(

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -260,6 +260,8 @@ def read_frames(
             else:  # stop_policy == "kill"
                 # Just kill it
                 p.kill()
+        # close stderr at the very end
+        p.stderr.close()
 
 
 def write_frames(

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -243,6 +243,10 @@ def read_frames(
                 # p.stdin.write(b"q")  # commented out in v0.4.1
                 p.stdout.close()
                 p.stdin.close()
+                try:
+                    p.stderr.close()
+                except Exception:
+                    pass
             except Exception as err:  # pragma: no cover
                 logger.warning("Error while attempting stop ffmpeg (r): " + str(err))
 
@@ -260,8 +264,6 @@ def read_frames(
             else:  # stop_policy == "kill"
                 # Just kill it
                 p.kill()
-        # close stderr at the very end
-        p.stderr.close()
 
 
 def write_frames(

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -224,6 +224,8 @@ def read_frames(
         raise
 
     finally:
+        # Stop the LogCatcher thread, which reads from stderr.
+        log_catcher.stop_me()
 
         # Make sure that ffmpeg is terminated.
         if p.poll() is None:
@@ -243,7 +245,6 @@ def read_frames(
                 # p.stdin.write(b"q")  # commented out in v0.4.1
                 p.stdout.close()
                 p.stdin.close()
-                log_catcher.stop_me()
                 p.stderr.close()
             except Exception as err:  # pragma: no cover
                 logger.warning("Error while attempting stop ffmpeg (r): " + str(err))

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -261,7 +261,7 @@ def read_frames(
                 # Just kill it
                 p.kill()
         # close stderr at the very end
-        # p.stderr.close()
+        p.stderr.close()
 
 
 def write_frames(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -8,7 +8,7 @@ import tempfile
 
 import imageio_ffmpeg
 
-from pytest import skip, raises
+from pytest import skip, raises, warns
 from testutils import no_warnings_allowed
 from testutils import ensure_test_files, test_dir, test_file1, test_file2, test_file3
 
@@ -29,6 +29,21 @@ def test_read_nframes():
     nframes, nsecs = imageio_ffmpeg.count_frames_and_secs(test_file1)
     assert nframes == 280
     assert 13.80 < nsecs < 13.99
+
+
+def test_read_frames_resource_warning():
+    """
+    Test issue #61: ensure no warnings are raised when the generator is closed
+
+    todo: use pytest.does_not_warn() as soon as it becomes available
+     (see https://github.com/pytest-dev/pytest/issues/9404)
+    """
+    with warns(None) as warnings:
+        gen = imageio_ffmpeg.read_frames(test_file1)
+        next(gen)
+        gen.close()
+    # there should not be any warnings, but show warning messages if there are
+    assert not [w.message for w in warnings]
 
 
 @no_warnings_allowed
@@ -376,6 +391,7 @@ if __name__ == "__main__":
     setup_module()
     test_ffmpeg_version()
     test_read_nframes()
+    test_read_frames_resource_warning()
     test_reading1()
     test_reading2()
     test_reading3()


### PR DESCRIPTION
This should fix issue #61.

My initial inclination was to call `p.stderr.close()` directly after closing `stdout` and `stdin`, [here](https://github.com/imageio/imageio-ffmpeg/blob/v0.4.5/imageio_ffmpeg/_io.py#L244). However, that caused `Windows fatal exception: access violation` in `test_io.py`.