### PR TITLE
Automatically find available h264 encoders and choose the best one according to our heuristics

### DIFF
--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -34,11 +34,16 @@ def ffmpeg_test_encoder(encoder):
     # Use the null streams to validate if we can encode anything
     # https://trac.ffmpeg.org/wiki/Null
     cmd = [
-        _get_exe(), "-hide_banner",
-        "-f", "lavfi",
-        "-i", "nullsrc=s=256x256:d=8",
-        "-vcodec", encoder,
-        "-f", "null",
+        _get_exe(), 
+        "-hide_banner",
+        "-f", 
+        "lavfi",
+        "-i", 
+        "nullsrc=s=256x256:d=8",
+        "-vcodec", 
+        encoder,
+        "-f", 
+        "null",
         "-",
     ]
     p = subprocess.run(

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -34,15 +34,15 @@ def ffmpeg_test_encoder(encoder):
     # Use the null streams to validate if we can encode anything
     # https://trac.ffmpeg.org/wiki/Null
     cmd = [
-        _get_exe(), 
+        _get_exe(),
         "-hide_banner",
-        "-f", 
+        "-f",
         "lavfi",
-        "-i", 
+        "-i",
         "nullsrc=s=256x256:d=8",
-        "-vcodec", 
+        "-vcodec",
         encoder,
-        "-f", 
+        "-f",
         "null",
         "-",
     ]
@@ -128,7 +128,8 @@ def get_first_available_h264_encoder():
             return encoder
     else:
         raise RuntimeError(
-            "No valid H.264 encoder was found with the ffmpeg installation")
+            "No valid H.264 encoder was found with the ffmpeg installation"
+        )
 
 
 @lru_cache()

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -15,8 +15,9 @@ h264_encoder_preference = defaultdict(lambda: -1)
 # The libx264 was the default encoder for a longe time with imageio
 h264_encoder_preference["libx264"] = 100
 
-# nvenc provides hardware encoding with NVIDIA graphics cards
-# nvenc_h264 and nvenc are the same encoder
+# Encoder with the nvidia graphics card dedicated hardware
+h264_encoder_preference["h264_nvenc"] = 90
+# Deprecated names for the same encoder
 h264_encoder_preference["nvenc_h264"] = 90
 h264_encoder_preference["nvenc"] = 90
 
@@ -107,7 +108,13 @@ def get_compiled_h264_encoders():
             encoders.append(encoder)
 
     encoders.sort(reverse=True, key=lambda x: h264_encoder_preference[x])
-    return encoders
+    if "h264_nvenc" in encoders:
+        # Remove deprecated names for the same encoder
+        for encoder in ["nvenc", "nvenc_h264"]:
+            if encoder in encoders:
+                encoders.remove(encoder)
+    # Return an immutable tuple to avoid users corrupting the lru_cache
+    return tuple(encoders)
 
 
 def get_first_available_h264_encoders():

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -117,7 +117,7 @@ def get_compiled_h264_encoders():
     return tuple(encoders)
 
 
-def get_first_available_h264_encoders():
+def get_first_available_h264_encoder():
     compiled_encoders = get_compiled_h264_encoders()
     for encoder in compiled_encoders:
         if ffmpeg_test_encoder(encoder):
@@ -495,7 +495,7 @@ def write_frames(
             # available on windows.
             codec = "msmpeg4"
         else:
-            codec = get_available_h264_encoders()[0]
+            codec = get_first_available_h264_encoder()
 
     audio_params = ["-an"]
     if audio_path is not None and not path.lower().endswith(".gif"):

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -30,7 +30,6 @@ h264_encoder_preference["libopenh264"] = 70
 h264_encoder_preference["libx264rgb"] = 50
 
 
-@lru_cache(maxsize=None)
 def ffmpeg_test_encoder(encoder):
     # Use the null streams to validate if we can encode anything
     # https://trac.ffmpeg.org/wiki/Null
@@ -51,7 +50,6 @@ def ffmpeg_test_encoder(encoder):
     return p.returncode == 0
 
 
-@lru_cache()
 def get_compiled_h264_encoders():
     cmd = [_get_exe(), "-hide_banner", "-encoders"]
     p = subprocess.run(
@@ -117,6 +115,7 @@ def get_compiled_h264_encoders():
     return tuple(encoders)
 
 
+@lru_cache()
 def get_first_available_h264_encoder():
     compiled_encoders = get_compiled_h264_encoders()
     for encoder in compiled_encoders:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -7,6 +7,7 @@ import types
 import tempfile
 
 import imageio_ffmpeg
+from imageio_ffmpeg._io import ffmpeg_test_encoder, get_compiled_h264_encoders
 
 from pytest import skip, raises, warns
 from testutils import no_warnings_allowed
@@ -411,6 +412,21 @@ def test_write_audio_path():
 
     assert nframes == 9
     assert audio_codec == "aac"
+
+
+def test_get_compiled_h264_encoders():
+    available_encoders = get_compiled_h264_encoders()
+    # Assert it is not a mutable type
+    assert isinstance(available_encoders, tuple)
+
+    # Software encoders like libx264 should work regardless of hardware
+    for encoder in ["libx264", "libopenh264", "libx264rgb"]:
+        if encoder in available_encoders:
+            assert ffmpeg_test_encoder(encoder)
+        else:
+            assert not ffmpeg_test_encoder(encoder)
+
+    assert not ffmpeg_test_encoder("not_a_real_encoder")
 
 
 if __name__ == "__main__":

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -8,6 +8,7 @@ import tempfile
 
 import imageio_ffmpeg
 from imageio_ffmpeg._io import ffmpeg_test_encoder, get_compiled_h264_encoders
+from imageio_ffmpeg._io import get_first_available_h264_encoder
 
 from pytest import skip, raises, warns
 from testutils import no_warnings_allowed
@@ -427,6 +428,15 @@ def test_get_compiled_h264_encoders():
             assert not ffmpeg_test_encoder(encoder)
 
     assert not ffmpeg_test_encoder("not_a_real_encoder")
+
+
+def test_prefered_encoder():
+    available_encoders = get_compiled_h264_encoders()
+    # historically, libx264 was the preferred encoder for imageio
+    # However, the user (or distribution) may not have it installed in their
+    # implementation of ffmpeg.
+    if "libx264" in available_encoders:
+        assert "libx264" == get_first_available_h264_encoder()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I tried to leave the defaults the same. But if x264 isn't available (for example, maybe a user doesn't want GPL), then it will gracefully fallback onto other encoders.