### PR TITLE
Fix pix_format parser to capture formats that have commas within strings

### DIFF
--- a/imageio_ffmpeg/_parsing.py
+++ b/imageio_ffmpeg/_parsing.py
@@ -135,7 +135,16 @@ def parse_ffmpeg_header(text):
     # Codec and pix_fmt hint
     line = videolines[0]
     meta["codec"] = line.split("Video: ", 1)[-1].lstrip().split(" ", 1)[0].strip()
-    meta["pix_fmt"] = line.split("Video: ", 1)[-1].split(",")[1].strip()
+    meta["pix_fmt"] = re.split(
+        # use a negative lookahead regexp to ignore commas that are contained
+        # within a parenthesis
+        # this helps consider a pix_fmt of the kind
+        #     yuv420p(tv, progressive)
+        # as what it is, instead of erroneously reporting as
+        #     yuv420p(tv
+        r",\s*(?![^()]*\))",
+        line.split("Video: ", 1)[-1],
+    )[1].strip()
 
     # get the output line that speaks about audio
     audiolines = [

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -163,9 +163,51 @@ def test_get_correct_rotation():
     assert info["rotate"] == 270
 
 
+def test_comma_in_pixel_format():
+    sample = dedent(
+        r"""
+        ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+          built with gcc 11.3.0 (conda-forge gcc 11.3.0-19)
+          configuration: --prefix=/home/conda/feedstock_root/build_artifacts/ffmpeg_1671040268898/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac --cc=/home/conda/feedstock_root/build_artifacts/ffmpeg_1671040268898/_build_env/bin/x86_64-conda-linux-gnu-cc --cxx=/home/conda/feedstock_root/build_artifacts/ffmpeg_1671040268898/_build_env/bin/x86_64-conda-linux-gnu-c++ --nm=/home/conda/feedstock_root/build_artifacts/ffmpeg_1671040268898/_build_env/bin/x86_64-conda-linux-gnu-nm --ar=/home/conda/feedstock_root/build_artifacts/ffmpeg_1671040268898/_build_env/bin/x86_64-conda-linux-gnu-ar --disable-doc --disable-openssl --enable-demuxer=dash --enable-hardcoded-tables --enable-libfreetype --enable-libfontconfig --enable-libopenh264 --enable-gnutls --enable-libmp3lame --enable-libvpx --enable-pthreads --enable-vaapi --disable-gpl --enable-libaom --enable-libsvtav1 --enable-libxml2 --enable-pic --enable-shared --disable-static --enable-version3 --enable-zlib --pkg-config=/home/conda/feedstock_root/build_artifacts/ffmpeg_1671040268898/_build_env/bin/pkg-config
+          libavutil      57. 28.100 / 57. 28.100
+          libavcodec     59. 37.100 / 59. 37.100
+          libavformat    59. 27.100 / 59. 27.100
+          libavdevice    59.  7.100 / 59.  7.100
+          libavfilter     8. 44.100 /  8. 44.100
+          libswscale      6.  7.100 /  6.  7.100
+          libswresample   4.  7.100 /  4.  7.100
+        Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '/tmp/pytest-of-mark/pytest-39/test_writer_pixelformat_size_v0/test.mp4':
+          Metadata:
+            major_brand     : isom
+            minor_version   : 512
+            compatible_brands: isomiso2avc1mp41
+            encoder         : Lavf59.27.100
+          Duration: 00:00:00.40, start: 0.000000, bitrate: 18 kb/s
+          Stream #0:0[0x1](und): Video: h264 (Constrained Baseline) (avc1 / 0x31637661), yuv420p(tv, progressive), 64x64, 1 kb/s, 10 fps, 10 tbr, 10240 tbn (default)
+            Metadata:
+              handler_name    : VideoHandler
+              vendor_id       : [0][0][0][0]
+              encoder         : Lavc59.37.100 libopenh264
+        Stream mapping:
+          Stream #0:0 -> #0:0 (h264 (native) -> rawvideo (native))
+        Press [q] to stop, [?] for help
+        Output #0, image2pipe, to 'pipe:':
+          Metadata:
+            major_brand     : isom
+            minor_version   : 512
+            compatible_brands: isomiso2avc1mp41
+            encoder         : Lavf59.27.100
+          Stream #0:0(und): Video: rawvideo (RGB[24] / 0x18424752), rgb24(pc, gbr/unknown/unknown, progressive), 64x64, q=2-31, 983 kb/s, 10 fps, 10 tbn (default)
+    """
+    )
+    info = parse_ffmpeg_header(sample)
+    assert info["pix_fmt"] == "yuv420p(tv, progressive)"
+
+
 if __name__ == "__main__":
     test_cvsecs()
     test_limit_lines()
     test_get_correct_fps1()
     test_get_correct_fps2()
     test_get_correct_rotation()
+    test_comma_in_pixel_format()


### PR DESCRIPTION
Closes https://github.com/imageio/imageio-ffmpeg/issues/78