### PR TITLE
detect m1 macs correctly for ffmpeg filenames

### DIFF
--- a/imageio_ffmpeg/_definitions.py
+++ b/imageio_ffmpeg/_definitions.py
@@ -1,3 +1,4 @@
+import platform
 import sys
 import struct
 
@@ -7,7 +8,6 @@ __version__ = "0.4.8"
 def get_platform():
     bits = struct.calcsize("P") * 8
     if sys.platform.startswith("linux"):
-        import platform
         architecture = platform.machine()
         if architecture == "aarch64":
             return "linuxaarch64"

--- a/imageio_ffmpeg/_definitions.py
+++ b/imageio_ffmpeg/_definitions.py
@@ -7,6 +7,10 @@ __version__ = "0.4.8"
 def get_platform():
     bits = struct.calcsize("P") * 8
     if sys.platform.startswith("linux"):
+        import platform
+        architecture = platform.machine()
+        if architecture == "aarch64":
+            return "linuxaarch64"
         return "linux{}".format(bits)
     elif sys.platform.startswith("freebsd"):
         return "freebsd{}".format(bits)


### PR DESCRIPTION
When I was trying to run moviepy in a docker container (Docker for Mac on M1). I got the error:
`RuntimeError: No ffmpeg exe could be found. Install ffmpeg on your system, or set the IMAGEIO_FFMPEG_EXE environment variable.`

Digging into the source of the issue, it was detecting the platform as `linux64` instead of `linuxaarch64`. manually patching this on my machine fixed it, so I thought I would upstream it.

I think it'll resolve https://github.com/imageio/imageio-ffmpeg/issues/71