### PR TITLE
Add GH Sponsors Link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: "imageio"
 tidelift: "pypi/imageio-ffmpeg"


### PR DESCRIPTION
@almarklein ImageIO is now approved to receive donations via GitHub Sponsors. I've added a link in the main repo, but let's also add one here.