### PR TITLE
Updated deprecated test approach + minor changes

### DIFF
--- a/imageio_ffmpeg/__init__.py
+++ b/imageio_ffmpeg/__init__.py
@@ -4,5 +4,5 @@
 # flake8: noqa
 
 from ._definitions import __version__
-from ._utils import get_ffmpeg_exe, get_ffmpeg_version
 from ._io import count_frames_and_secs, read_frames, write_frames
+from ._utils import get_ffmpeg_exe, get_ffmpeg_version

--- a/imageio_ffmpeg/_definitions.py
+++ b/imageio_ffmpeg/_definitions.py
@@ -1,6 +1,6 @@
 import platform
-import sys
 import struct
+import sys
 
 __version__ = "0.4.8"
 

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -1,13 +1,12 @@
-import sys
-import time
 import pathlib
 import subprocess
-from functools import lru_cache
+import sys
+import time
 from collections import defaultdict
+from functools import lru_cache
 
-from ._utils import get_ffmpeg_exe, _popen_kwargs, logger
-from ._parsing import LogCatcher, parse_ffmpeg_header, cvsecs
-
+from ._parsing import LogCatcher, cvsecs, parse_ffmpeg_header
+from ._utils import _popen_kwargs, get_ffmpeg_exe, logger
 
 ISWIN = sys.platform.startswith("win")
 

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -317,7 +317,7 @@ def read_frames(
             try:
                 bb = bytes()
                 while len(bb) < framesize_bytes:
-                    extra_bytes = p.stdout.read(framesize_bytes - len(bb))
+                    extra_bytes = process.stdout.read(framesize_bytes - len(bb))
                     if not extra_bytes:
                         if len(bb) == 0:
                             return

--- a/imageio_ffmpeg/_io.py
+++ b/imageio_ffmpeg/_io.py
@@ -163,7 +163,9 @@ def count_frames_and_secs(path):
         out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, **_popen_kwargs())
     except subprocess.CalledProcessError as err:
         out = err.output.decode(errors="ignore")
-        raise RuntimeError("FFMEG call failed with {}:\n{}".format(err.returncode, out))
+        raise RuntimeError(
+            "FFMPEG call failed with {}:\n{}".format(err.returncode, out)
+        )
 
     # Note that other than with the subprocess calls below, ffmpeg wont hang here.
     # Worst case Python will stop/crash and ffmpeg will continue running until done.

--- a/imageio_ffmpeg/_parsing.py
+++ b/imageio_ffmpeg/_parsing.py
@@ -1,6 +1,6 @@
 import re
-import time
 import threading
+import time
 
 from ._utils import logger
 

--- a/imageio_ffmpeg/_utils.py
+++ b/imageio_ffmpeg/_utils.py
@@ -1,11 +1,12 @@
-import os
-import sys
 import logging
+import os
 import subprocess
+import sys
 from functools import lru_cache
+
 from pkg_resources import resource_filename
 
-from ._definitions import get_platform, FNAME_PER_PLATFORM
+from ._definitions import FNAME_PER_PLATFORM, get_platform
 
 logger = logging.getLogger("imageio_ffmpeg")
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,11 +1,11 @@
 """ Invoke tasks for imageio-ffmpeg
 """
 
-import os
-import sys
-import shutil
 import importlib
+import os
+import shutil
 import subprocess
+import sys
 from urllib.request import urlopen
 
 from invoke import task
@@ -138,7 +138,7 @@ def build(ctx):
     # Get version and more
     sys.path.insert(0, os.path.join(ROOT_DIR, "imageio_ffmpeg"))
     try:
-        from _definitions import __version__, FNAME_PER_PLATFORM, WHEEL_BUILDS
+        from _definitions import FNAME_PER_PLATFORM, WHEEL_BUILDS, __version__
     finally:
         sys.path.pop(0)
 
@@ -236,6 +236,7 @@ def update_readme(ctx):
     text = text.split("\n## API\n")[0] + "\n## API\n\n"
 
     import inspect
+
     import imageio_ffmpeg
 
     for func in (

--- a/tests/snippets.py
+++ b/tests/snippets.py
@@ -11,7 +11,9 @@ use-cases. Some may depend on imageio.
 # is now to wait for ffmpeg.
 
 import os
+
 import numpy as np
+
 import imageio_ffmpeg
 
 ims = [
@@ -30,6 +32,7 @@ w.close()
 # %% Behavior of KeyboardInterrupt / Ctrl+C
 
 import os
+
 import imageio_ffmpeg
 
 filename = os.path.expanduser("~/.imageio/images/cockatoo.mp4")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,17 +2,27 @@
 The main tests for the public API.
 """
 
+import tempfile
 import time
 import types
-import tempfile
+import warnings
+
+from pytest import raises, skip, warns
+from testutils import (
+    ensure_test_files,
+    no_warnings_allowed,
+    test_dir,
+    test_file1,
+    test_file2,
+    test_file3,
+)
 
 import imageio_ffmpeg
-from imageio_ffmpeg._io import ffmpeg_test_encoder, get_compiled_h264_encoders
-from imageio_ffmpeg._io import get_first_available_h264_encoder
-
-from pytest import skip, raises, warns
-from testutils import no_warnings_allowed
-from testutils import ensure_test_files, test_dir, test_file1, test_file2, test_file3
+from imageio_ffmpeg._io import (
+    ffmpeg_test_encoder,
+    get_compiled_h264_encoders,
+    get_first_available_h264_encoder,
+)
 
 
 def setup_module():
@@ -40,12 +50,13 @@ def test_read_frames_resource_warning():
     todo: use pytest.does_not_warn() as soon as it becomes available
      (see https://github.com/pytest-dev/pytest/issues/9404)
     """
-    with warns(None) as warnings:
+
+    with warnings.catch_warnings(record=True) as warnings_:
         gen = imageio_ffmpeg.read_frames(test_file1)
         next(gen)
         gen.close()
     # there should not be any warnings, but show warning messages if there are
-    assert not [w.message for w in warnings]
+    assert not [w.message for w in warnings_]
 
 
 @no_warnings_allowed

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -8,21 +8,13 @@ import types
 import warnings
 
 from pytest import raises, skip, warns
-from testutils import (
-    ensure_test_files,
-    no_warnings_allowed,
-    test_dir,
-    test_file1,
-    test_file2,
-    test_file3,
-)
+from testutils import (ensure_test_files, no_warnings_allowed, test_dir,
+                       test_file1, test_file2, test_file3)
 
 import imageio_ffmpeg
-from imageio_ffmpeg._io import (
-    ffmpeg_test_encoder,
-    get_compiled_h264_encoders,
-    get_first_available_h264_encoder,
-)
+from imageio_ffmpeg._io import (ffmpeg_test_encoder,
+                                get_compiled_h264_encoders,
+                                get_first_available_h264_encoder)
 
 
 def setup_module():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -7,7 +7,7 @@ import time
 import types
 import warnings
 
-from pytest import raises, skip, warns
+from pytest import raises, skip
 from testutils import (
     ensure_test_files,
     no_warnings_allowed,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -8,13 +8,21 @@ import types
 import warnings
 
 from pytest import raises, skip, warns
-from testutils import (ensure_test_files, no_warnings_allowed, test_dir,
-                       test_file1, test_file2, test_file3)
+from testutils import (
+    ensure_test_files,
+    no_warnings_allowed,
+    test_dir,
+    test_file1,
+    test_file2,
+    test_file3,
+)
 
 import imageio_ffmpeg
-from imageio_ffmpeg._io import (ffmpeg_test_encoder,
-                                get_compiled_h264_encoders,
-                                get_first_available_h264_encoder)
+from imageio_ffmpeg._io import (
+    ffmpeg_test_encoder,
+    get_compiled_h264_encoders,
+    get_first_available_h264_encoder,
+)
 
 
 def setup_module():

--- a/tests/test_special.py
+++ b/tests/test_special.py
@@ -5,9 +5,9 @@ import gc
 import queue
 import threading
 
-import imageio_ffmpeg
-
 from testutils import ensure_test_files, test_file1
+
+import imageio_ffmpeg
 
 
 def setup_module():

--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -5,14 +5,18 @@ quits nicely (instead of being killed).
 """
 
 import gc
-import sys
 import subprocess
+import sys
+
+from testutils import (
+    ensure_test_files,
+    get_ffmpeg_pids,
+    no_warnings_allowed,
+    test_file1,
+    test_file2,
+)
 
 import imageio_ffmpeg
-
-from testutils import no_warnings_allowed, get_ffmpeg_pids
-from testutils import ensure_test_files, test_file1, test_file2
-
 
 N = 2  # number of times to perform each test
 
@@ -30,7 +34,7 @@ def test_ffmpeg_version():
 
 @no_warnings_allowed
 def test_reader_done():
-    for i in range(N):
+    for _ in range(N):
         pids0 = get_ffmpeg_pids()
         r = imageio_ffmpeg.read_frames(test_file1)
         pids1 = get_ffmpeg_pids().difference(pids0)  # generator has not started
@@ -47,7 +51,7 @@ def test_reader_done():
 
 @no_warnings_allowed
 def test_reader_close():
-    for i in range(N):
+    for _ in range(N):
         pids0 = get_ffmpeg_pids()
         r = imageio_ffmpeg.read_frames(test_file1)
         pids1 = get_ffmpeg_pids().difference(pids0)  # generator has not started
@@ -63,7 +67,7 @@ def test_reader_close():
 
 @no_warnings_allowed
 def test_reader_del():
-    for i in range(N):
+    for _ in range(N):
         pids0 = get_ffmpeg_pids()
         r = imageio_ffmpeg.read_frames(test_file1)
         pids1 = get_ffmpeg_pids().difference(pids0)  # generator has not started
@@ -80,7 +84,7 @@ def test_reader_del():
 
 @no_warnings_allowed
 def test_write_close():
-    for i in range(N):
+    for _ in range(N):
         pids0 = get_ffmpeg_pids()
         w = imageio_ffmpeg.write_frames(test_file2, (64, 64))
         pids1 = get_ffmpeg_pids().difference(pids0)  # generator has not started
@@ -97,7 +101,7 @@ def test_write_close():
 
 @no_warnings_allowed
 def test_write_del():
-    for i in range(N):
+    for _ in range(N):
         pids0 = get_ffmpeg_pids()
         w = imageio_ffmpeg.write_frames(test_file2, (64, 64))
         pids1 = get_ffmpeg_pids().difference(pids0)  # generator has not started
@@ -116,7 +120,7 @@ def test_write_del():
 def test_partial_read():
     # Case: https://github.com/imageio/imageio-ffmpeg/issues/69
     template = "import sys; import imageio_ffmpeg; f=sys.argv[1]; print(f); r=imageio_ffmpeg.read_frames(f);"
-    for i in range(4):
+    for _ in range(4):
         code = template + " r.__next__();" * i
         cmd = [sys.executable, "-c", code, test_file1]
         result = subprocess.run(

--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -8,13 +8,8 @@ import gc
 import subprocess
 import sys
 
-from testutils import (
-    ensure_test_files,
-    get_ffmpeg_pids,
-    no_warnings_allowed,
-    test_file1,
-    test_file2,
-)
+from testutils import (ensure_test_files, get_ffmpeg_pids, no_warnings_allowed,
+                       test_file1, test_file2)
 
 import imageio_ffmpeg
 

--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -8,8 +8,13 @@ import gc
 import subprocess
 import sys
 
-from testutils import (ensure_test_files, get_ffmpeg_pids, no_warnings_allowed,
-                       test_file1, test_file2)
+from testutils import (
+    ensure_test_files,
+    get_ffmpeg_pids,
+    no_warnings_allowed,
+    test_file1,
+    test_file2,
+)
 
 import imageio_ffmpeg
 

--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -34,6 +34,7 @@ def test_ffmpeg_version():
 
 @no_warnings_allowed
 def test_reader_done():
+    """Test that the reader is done after reading all frames"""
     for _ in range(N):
         pids0 = get_ffmpeg_pids()
         r = imageio_ffmpeg.read_frames(test_file1)
@@ -51,6 +52,7 @@ def test_reader_done():
 
 @no_warnings_allowed
 def test_reader_close():
+    """Test that the reader is done after closing it"""
     for _ in range(N):
         pids0 = get_ffmpeg_pids()
         r = imageio_ffmpeg.read_frames(test_file1)
@@ -67,6 +69,7 @@ def test_reader_close():
 
 @no_warnings_allowed
 def test_reader_del():
+    """Test that the reader is done after deleting it"""
     for _ in range(N):
         pids0 = get_ffmpeg_pids()
         r = imageio_ffmpeg.read_frames(test_file1)
@@ -84,6 +87,7 @@ def test_reader_del():
 
 @no_warnings_allowed
 def test_write_close():
+    """Test that the writer is done after closing it"""
     for _ in range(N):
         pids0 = get_ffmpeg_pids()
         w = imageio_ffmpeg.write_frames(test_file2, (64, 64))
@@ -119,8 +123,11 @@ def test_write_del():
 
 def test_partial_read():
     # Case: https://github.com/imageio/imageio-ffmpeg/issues/69
-    template = "import sys; import imageio_ffmpeg; f=sys.argv[1]; print(f); r=imageio_ffmpeg.read_frames(f);"
-    for _ in range(4):
+    template = (
+        "import sys; import imageio_ffmpeg; f=sys.argv[1]; print(f); "
+        "r=imageio_ffmpeg.read_frames(f);"
+    )
+    for i in range(4):
         code = template + " r.__next__();" * i
         cmd = [sys.executable, "-c", code, test_file1]
         result = subprocess.run(

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,12 +1,11 @@
+import logging.handlers
 import os
 import tempfile
-import logging.handlers
 from urllib.request import urlopen
 
 import psutil
 
 import imageio_ffmpeg
-
 
 test_dir = tempfile.gettempdir()
 test_url1 = "https://raw.githubusercontent.com/imageio/imageio-binaries/master/images/cockatoo.mp4"


### PR DESCRIPTION
## Major changes

1. Replaced `with warns(None) as warnings:` with a new syntax by importing the warnings module and `with warnings.catch_warnings(record=True) as warnings_:`. This turned one of the pytest warning to a pytest passed.

## Minor changes

1. Fixed type from `FFMEG` to `FFMPEG`
2. Replaced the variable `i` with `_` for for-loops that do not utilize `i`
3. Replaced variable names with more descriptive ones: `w` -> `width`, `h` -> `height`, `p` -> `process`

## Patch changes

1. Ran `isort .`
2. Ran `black .`