### PR TITLE
Check CI pypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Py versions
+          # Python versions
           - name: Linux py37
             os: ubuntu-latest
             pyversion: '3.7'

--- a/tests/test_special.py
+++ b/tests/test_special.py
@@ -2,12 +2,17 @@
 """
 
 import gc
+import sys
 import queue
 import threading
 
 from testutils import ensure_test_files, test_file1
+import pytest
 
 import imageio_ffmpeg
+
+
+IS_PYPY = "__pypy__" in sys.builtin_module_names
 
 
 def setup_module():
@@ -23,6 +28,9 @@ def make_iterator(q, n):
 
 def test_threading():
     # See issue #20
+
+    if IS_PYPY:
+        pytest.xfail("These threads hang on pypy for some reason.")
 
     num_threads = 16
     num_frames = 5

--- a/tests/test_special.py
+++ b/tests/test_special.py
@@ -37,8 +37,8 @@ def test_threading():
 
     for i in range(num_threads * num_frames):
         print(i, end=" ")
-        q.get()
         gc.collect()  # this seems to help invoke the segfault earlier
+        q.get()
 
 
 if __name__ == "__main__":

--- a/tests/test_special.py
+++ b/tests/test_special.py
@@ -14,17 +14,18 @@ def setup_module():
     ensure_test_files()
 
 
+def make_iterator(q, n):
+    for i in range(n):
+        gen = imageio_ffmpeg.read_frames(test_file1)
+        gen.__next__()  # meta data
+        q.put(gen.__next__())  # first frame
+
+
 def test_threading():
     # See issue #20
 
     num_threads = 16
     num_frames = 5
-
-    def make_iterator(q, n):
-        for i in range(n):
-            gen = imageio_ffmpeg.read_frames(test_file1)
-            gen.__next__()  # meta data
-            q.put(gen.__next__())  # first frame
 
     q = queue.Queue()
     threads = []
@@ -41,5 +42,5 @@ def test_threading():
 
 
 if __name__ == "__main__":
-    # setup_module()
+    setup_module()
     test_threading()

--- a/tests/test_special.py
+++ b/tests/test_special.py
@@ -38,7 +38,7 @@ def test_threading():
     for i in range(num_threads * num_frames):
         print(i, end=" ")
         gc.collect()  # this seems to help invoke the segfault earlier
-        q.get()
+        q.get(timeout=20)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For some reason, the `test_threading()` test started failing on pypy. There does not seem to be a difference in the pypy version compared to the last CI-run that passed.  